### PR TITLE
Fix NullPointerException crash on some servers.

### DIFF
--- a/src/main/java/de/joh/fnc/api/event/ShouldCauseWildMagicEvent.java
+++ b/src/main/java/de/joh/fnc/api/event/ShouldCauseWildMagicEvent.java
@@ -41,7 +41,7 @@ public class ShouldCauseWildMagicEvent extends LivingEvent {
     public ShouldCauseWildMagicEvent(LivingEntity entity) {
         super(entity);
 
-        if(entity.hasEffect(EffectInit.WILD_MAGIC_COOLDOWN.get())){
+        if(entity == null || entity.hasEffect(EffectInit.WILD_MAGIC_COOLDOWN.get())){
             this.autoFail = true;
             this.chance = 0;
             return;


### PR DESCRIPTION
There's an occasional serverside crash that happens on a server I'm an admin for. I don't know exactly why the crash happens, but I added a check to the offending function to prevent the NullPointerException.