### PR TITLE
Fix server console log spam

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ dependencies {
 
     // M&A and its API
     // compileOnly "com.mithion:mna:${mna_version}:api" //api, compilation only
-    implementation fg.deobf("com.mithion:mna-forge-${minecraft_version}:${mna_version}:all") //mod itself, deobf for runtime
+    implementation fg.deobf("curse.maven:mana-and-artifice-${mna_projectId}:${mna_fileId}")
 
     //DM&R
     implementation fg.deobf("curse.maven:dragonmagicandrelics-785039:${dmnr_curse_version_id}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,8 @@ mod_description=A mod that expands the world of magic to include additional fact
 
 # Mod versions
 curios_version=5.4.7+1.20.1
-mna_version=3.0.0.10
 caelus_version=3.1.0+1.20
 dmnr_curse_version_id=5054416
+mna_projectId = 406360
+mna_fileId = 5722513
+mna_version_range = [3.1.0.1,4)

--- a/src/main/java/de/joh/fnc/common/event/MagicEventHandler.java
+++ b/src/main/java/de/joh/fnc/common/event/MagicEventHandler.java
@@ -45,10 +45,13 @@ public class MagicEventHandler {
      */
     @SubscribeEvent
     public static void onSpellCast(SpellCastEvent event){
-        Player caster = event.getCaster();
+        LivingEntity caster = event.getSource().getCaster();
 
-        if(caster.getItemBySlot(EquipmentSlot.OFFHAND).getItem() instanceof DebugOrbSpellAdjustmentItem debugOrbSpellAdjustmentItem){
-            debugOrbSpellAdjustmentItem.useSpellAdjustment(caster.level(), caster, caster.getItemBySlot(EquipmentSlot.OFFHAND), event);
+        if (caster instanceof Player)
+        {
+            if(caster.getItemBySlot(EquipmentSlot.OFFHAND).getItem() instanceof DebugOrbSpellAdjustmentItem debugOrbSpellAdjustmentItem){
+                debugOrbSpellAdjustmentItem.useSpellAdjustment(caster.level(), (Player)caster, caster.getItemBySlot(EquipmentSlot.OFFHAND), event);
+            }
         }
 
         //todo: outsource as Event


### PR DESCRIPTION
Fixes Imps now being able to use spells from spamming the server log any time they cast a spell, simple instanceof Player check before grabbing the debug orb item and applying adjustments. Tweaked the gradle MnA version/formatting since the preexisting format wasn't working for me (feel free to revert those changes if problems occur for you).